### PR TITLE
Problem with Cyrillic anchors

### DIFF
--- a/js/catalog.js
+++ b/js/catalog.js
@@ -100,7 +100,7 @@ $(".my-grid").each(function(){
    })		
 
    
-var hash = window.location.hash;
+var hash = decodeURI(window.location.hash);
 var noHash=hash.replace("#","");
 	if(hash){
 		mix_init_cat(noHash);


### PR DESCRIPTION
When a page has Cyrillic anchors, its reload finish with an error on line 103.
Decoding of var hash solves this problem.